### PR TITLE
chore: add .cve-fix/examples.md guidance for CVE fixer workflow

### DIFF
--- a/.cve-fix/examples.md
+++ b/.cve-fix/examples.md
@@ -1,0 +1,24 @@
+<!-- last-analyzed: 2026-04-22 | cve-merged: 0 -->
+
+<!-- Insufficient PR history for full pattern extraction.
+     Update with /guidance.update after more CVE fixes are merged. -->
+
+## Titles
+- No CVE fix PRs found in history yet
+
+## Branches
+- Suggested: `fix/cve-YYYY-XXXXX-<package>` (follow CVE fixer workflow convention)
+
+## Files
+- Dependency files likely include: `requirements.txt`, `Pipfile`, `pyproject.toml`, lock files
+- Check subdirectories for per-image requirements files
+
+## Co-upgrades
+- No patterns established yet
+
+## PR Description
+- Include CVE ID, affected package, version change
+- Reference Jira issue
+
+## Don'ts
+- No patterns established yet


### PR DESCRIPTION
Adds `.cve-fix/examples.md` so the CVE fixer workflow knows how to
create fix PRs matching this repo's conventions (branch naming, files that
change together, co-upgrades, etc.).

Generated by `/onboard` based on analysis of merged CVE PRs.

> **Note:** No CVE fix PR history was found in this repo yet. The guidance
> file contains minimal scaffolding. Run `/guidance.update` after more CVE
> fixes are merged to improve the patterns.

🤖 Generated by /onboard